### PR TITLE
Fix backwards compatability issue for language_id

### DIFF
--- a/src/chatterbox/tts.py
+++ b/src/chatterbox/tts.py
@@ -209,7 +209,7 @@ class ChatterboxTTS:
     def generate(
         self,
         text,
-        language_id, # for API compatibility; not used in this model
+        language_id=None, # for API compatibility; not used in this model
         audio_prompt_path=None,
         exaggeration=0.5,
         cfg_weight=0.5,


### PR DESCRIPTION
Set `language_id` parameter to a default value to maintain backwards compatibility.

With this default value, the following example would throw an error:

```py
model.generate(
    "Example string",
    audio_prompt_path=audio_prompt_path
)
```