### PR TITLE
fix: handle short audio outputs in s3gen fade application

### DIFF
--- a/src/chatterbox/models/s3gen/s3gen.py
+++ b/src/chatterbox/models/s3gen/s3gen.py
@@ -259,7 +259,8 @@ class S3Token2Wav(S3Token2Mel):
 
         if not self.training:
             # NOTE: ad-hoc method to reduce "spillover" from the reference clip.
-            output_wavs[:, :len(self.trim_fade)] *= self.trim_fade
+            fade_len = min(output_wavs.size(1), len(self.trim_fade))
+            output_wavs[:, :fade_len] *= self.trim_fade[:fade_len]
 
         return output_wavs
 
@@ -300,6 +301,7 @@ class S3Token2Wav(S3Token2Mel):
 
         # NOTE: ad-hoc method to reduce "spillover" from the reference clip.
         if not no_trim:
-            output_wavs[:, :len(self.trim_fade)] *= self.trim_fade
+            fade_len = min(output_wavs.size(1), len(self.trim_fade))
+            output_wavs[:, :fade_len] *= self.trim_fade[:fade_len]
 
         return output_wavs, output_sources


### PR DESCRIPTION
This PR fixes an issue when the generated audio is shorter than fade_len (40ms), which causes an exception (it happened several times for me).

For an audio longer than 40ms it doesn't affect the behavior.